### PR TITLE
Implement a new "Daily reset" solution

### DIFF
--- a/inverter/__init__.py
+++ b/inverter/__init__.py
@@ -3,5 +3,5 @@
     Get information from Deye Microinverter
 """
 
-__version__ = '0.10.3'
+__version__ = '0.11.0'
 __author__ = 'Jens Diemer <inverter-connect@jensdiemer.de>'

--- a/inverter/cli/cli_app.py
+++ b/inverter/cli/cli_app.py
@@ -577,6 +577,7 @@ def publish_loop(ip, port, inverter, verbosity: int):
 
     config = make_config(
         user_settings=user_settings,
+        config_path=toml_settings.file_path.parent,  # e.g.: ~/.config/inverter-connect/
         verbosity=verbosity,
         ip=ip,
         port=port,

--- a/inverter/data_types.py
+++ b/inverter/data_types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-from datetime import datetime, time
 from enum import Enum
 from pathlib import Path
 from typing import Callable
@@ -75,8 +74,7 @@ class Config:
     init_cmd: bytes = b'WIFIKIT-214028-READ'
 
     daily_production_name: str = 'Daily Production'  # Must be the same as in yaml config!
-    reset_needed_start: time = time(hour=1)
-    reset_needed_end: time = time(hour=3)
+    config_path: Path = None  # e.g.: ~/.config/inverter-connect/
 
     # Will be set by post init:
     definition_file_path: Path = None
@@ -100,15 +98,6 @@ class Config:
 
         if self.verbosity > 1:
             print(self)
-
-
-@dataclasses.dataclass
-class ResetState:
-    started: datetime
-    set_time_count: int = 0
-    successful_count: int = 0
-    last_success_dt: datetime = None
-    reset_needed: bool = False
 
 
 @dataclasses.dataclass

--- a/inverter/publish_loop.py
+++ b/inverter/publish_loop.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from datetime import datetime
 
 from ha_services.cli_tools.rich_utils import human_error
 from ha_services.mqtt4homeassistant.converter import values2mqtt_payload
@@ -11,8 +10,8 @@ from rich import print  # noqa
 
 from inverter.api import Inverter
 from inverter.constants import ERROR_STR_NO_DATA
-from inverter.daily_reset import DailyProductionReset
-from inverter.data_types import Config, InverterInfo, InverterValue, ResetState
+from inverter.daily_reset import DailyProductionReset, DailyProductionResetState
+from inverter.data_types import Config, InverterInfo, InverterValue
 from inverter.exceptions import ReadInverterError, ReadTimeout, ValidationError
 
 
@@ -28,7 +27,7 @@ def publish_forever(*, config: Config, verbosity):
     except Exception as err:
         human_error(message='given {mqtt_settings!r} is wrong?!?', exception=err)
 
-    reset_state = ResetState(started=datetime.now())
+    reset_state = DailyProductionResetState(config_path=config.config_path)
 
     while True:
         try:

--- a/inverter/tests/test_daily_reset.py
+++ b/inverter/tests/test_daily_reset.py
@@ -1,137 +1,214 @@
 import logging
-from datetime import datetime, timedelta
+import tempfile
+from datetime import timedelta
+from pathlib import Path
 from unittest import TestCase
 
 from freezegun import freeze_time
 
-from inverter.daily_reset import DailyProductionReset
-from inverter.data_types import InverterValue, ResetState, ValueType
+from inverter.daily_reset import DailyProductionReset, DailyProductionResetState
+from inverter.data_types import InverterValue, ValueType
 from inverter.tests import fixtures
 
 
 class DailyProductionResetTestCase(TestCase):
     @freeze_time('2020-01-01T00:00:00+0000', as_kwarg='frozen_time')
     def test_happy_path(self, frozen_time):
-        start_dt = datetime.now()
+        with tempfile.TemporaryDirectory(prefix='test-inverter-connect') as temp_dir:
+            temp_path = Path(temp_dir)
 
-        reset_state = ResetState(started=start_dt)
-        self.assertEqual(reset_state.started.isoformat(), '2020-01-01T00:00:00')
+            reset_state = DailyProductionResetState(config_path=temp_path)
+            # On start, without a state file, the fallback is to don't reset on the same day:
+            self.assertEqual(str(reset_state), 'self.last_reset=FakeDate(2020, 1, 1) self.reset_done_today=True')
 
-        class InverterMock:
-            writes = []
+            class InverterMock:
+                writes = []
 
-            def __init__(self):
-                self.inv_sock = self
+                def __init__(self):
+                    self.inv_sock = self
 
-            def write(self, *, address, values):
-                self.writes.append((address, values))
+                def write(self, *, address, values):
+                    self.writes.append((address, values))
 
-        inverter = InverterMock()
-        config = fixtures.get_config()
+            inverter = InverterMock()
+            config = fixtures.get_config()
 
-        with DailyProductionReset(reset_state, inverter, config) as daily_production_reset:
-            self.assertEqual(
-                daily_production_reset.reset_state,
-                ResetState(started=start_dt, set_time_count=0, successful_count=0, reset_needed=False),
-            )
+            # On start, without a state file, the fallback is to do no reset on the same day:
+            with DailyProductionReset(reset_state, inverter, config) as daily_production_reset:
+                self.assertIs(daily_production_reset.reset_state.reset_done_today, True)
 
-        other_value = InverterValue(
-            type=ValueType.COMPUTED,
-            name='Total Power',
-            value=80,
-            device_class='power',
-            state_class='measurement',
-            unit='W',
-            result=None,
-        )
+                with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                    daily_production_reset(
+                        value='Fake InverterValue',  # noqa
+                    )
+                self.assertEqual(
+                    logs.output,
+                    [
+                        'DEBUG:inverter.daily_reset:Not needed: self.last_reset=FakeDate(2020, 1, 1) '
+                        'self.reset_done_today=True'
+                    ],
+                )
 
-        frozen_time.move_to('2020-01-01T00:59:59')
-        with DailyProductionReset(reset_state, inverter, config) as daily_production_reset:
-            # Not config.reset_needed_start -> False
-            self.assertIs(daily_production_reset.reset_state.reset_needed, False)
+                # Next day a reset is needed:
+                frozen_time.tick(delta=timedelta(days=1))
+                self.assertIs(daily_production_reset.reset_state.reset_done_today, False)
 
-            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
-                daily_production_reset(value=other_value)
-            self.assertEqual(
-                logs.output,
-                [
-                    'DEBUG:inverter.daily_reset:Not needed: ResetState(started=FakeDatetime(2020, '
-                    '1, 1, 0, 0), set_time_count=0, successful_count=0, last_success_dt=None, '
-                    'reset_needed=False)'
-                ],
-            )
-            self.assertEqual(inverter.writes, [])
-
-        frozen_time.move_to('2020-01-01T01:00:00')
-        with DailyProductionReset(reset_state, inverter, config) as daily_production_reset:
-            # We are now in config.reset_needed_start -> True
-            self.assertIs(daily_production_reset.reset_state.reset_needed, True)
-
-            # Ignore all non 'Daily Production' values:
-
-            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
-                daily_production_reset(value=other_value)
-            self.assertEqual(
-                logs.output, ["DEBUG:inverter.daily_reset:Ignore 'Total Power' (It is not 'Daily Production')"]
-            )
-            self.assertEqual(inverter.writes, [])
-
-            # set current time, two times:
-
-            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
-                for _ in range(2):
-                    frozen_time.tick(delta=timedelta(minutes=2))
+                # Ignore all non 'Daily Production' values:
+                with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
                     daily_production_reset(
                         value=InverterValue(
-                            type=ValueType.READ_OUT,
-                            name='Daily Production',
-                            value=1,  # <<< last reset not successfully
+                            type=ValueType.COMPUTED,
+                            name='Total Power',  # <<< it's not the correct value -> ignore
+                            value=80,
                             device_class='power',
                             state_class='measurement',
-                            unit='kWh',
+                            unit='W',
                             result=None,
                         )
                     )
-            self.assertEqual(
-                logs.output,
-                [
-                    'INFO:inverter.daily_reset:set current time to reset counter '
-                    'ResetState(started=FakeDatetime(2020, 1, 1, 0, 0), set_time_count=1, '
-                    'successful_count=0, last_success_dt=None, reset_needed=True)',
-                    'INFO:inverter.daily_reset:set current time to reset counter '
-                    'ResetState(started=FakeDatetime(2020, 1, 1, 0, 0), set_time_count=2, '
-                    'successful_count=0, last_success_dt=None, reset_needed=True)',
-                ],
-            )
-            self.assertEqual(inverter.writes, [(22, [5121, 257, 512]), (22, [5121, 257, 1024])])
-            inverter.writes.clear()
+                self.assertEqual(
+                    logs.output, ["DEBUG:inverter.daily_reset:Ignore 'Total Power' (It is not 'Daily Production')"]
+                )
+                self.assertEqual(inverter.writes, [])
 
-            # success, two times
+                # Trigger **two** times the reset:
 
-            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
-                for _ in range(2):
-                    frozen_time.tick(delta=timedelta(minutes=2))
-                    daily_production_reset(
-                        value=InverterValue(
-                            type=ValueType.READ_OUT,
-                            name='Daily Production',
-                            value=0,  # <<< success
-                            device_class='power',
-                            state_class='measurement',
-                            unit='kWh',
-                            result=None,
+                with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                    for _ in range(2):
+                        frozen_time.tick(delta=timedelta(minutes=2))
+                        daily_production_reset(
+                            value=InverterValue(
+                                type=ValueType.READ_OUT,
+                                name='Daily Production',
+                                value=1,  # <<< last reset not successfully
+                                device_class='power',
+                                state_class='measurement',
+                                unit='kWh',
+                                result=None,
+                            )
                         )
-                    )
+                self.assertEqual(
+                    logs.output,
+                    [
+                        # first call:
+                        'INFO:inverter.daily_reset:set current time to reset counter '
+                        'self.last_reset=FakeDate(2020, 1, 1) self.reset_done_today=False',
+                        #
+                        # Second call:
+                        'INFO:inverter.daily_reset:set current time to reset counter '
+                        'self.last_reset=FakeDate(2020, 1, 1) self.reset_done_today=False',
+                    ],
+                )
+                self.assertIs(daily_production_reset.reset_state.reset_done_today, False)
+                self.assertEqual(
+                    inverter.writes,
+                    [
+                        (22, [5121, 512, 512]),  # <<< set time 1
+                        (22, [5121, 512, 1024]),  # <<< set time 2
+                    ],
+                )
+                inverter.writes.clear()
+
+                # success, two times
+
+                with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                    for _ in range(2):
+                        frozen_time.tick(delta=timedelta(minutes=2))
+                        daily_production_reset(
+                            value=InverterValue(
+                                type=ValueType.READ_OUT,
+                                name='Daily Production',
+                                value=0,  # <<< success
+                                device_class='power',
+                                state_class='measurement',
+                                unit='kWh',
+                                result=None,
+                            )
+                        )
+                self.assertEqual(
+                    logs.output,
+                    [
+                        'INFO:inverter.daily_reset:Store today date 2020-01-02 to state file',
+                        #
+                        'INFO:inverter.daily_reset:Successfully reset counter. '
+                        'self.last_reset=FakeDate(2020, 1, 2) self.reset_done_today=True',
+                        #
+                        'DEBUG:inverter.daily_reset:Not needed: self.last_reset=FakeDate(2020, 1, 2) '
+                        'self.reset_done_today=True',
+                    ],
+                )
+                self.assertIs(daily_production_reset.reset_state.reset_done_today, True)
+                self.assertEqual(inverter.writes, [])  # no new set time writes
+
+    @freeze_time('2020-01-01T00:00:00+0000', as_kwarg='frozen_time')
+    def test_state(self, frozen_time):
+        with tempfile.TemporaryDirectory(prefix='test-inverter-connect') as temp_dir:
+            temp_path = Path(temp_dir)
+
+            with self.assertLogs(logger=None, level=logging.WARNING) as logs:
+                state = DailyProductionResetState(config_path=temp_path)
+            self.assertEqual(state.last_reset.isoformat(), '2020-01-01')
+            self.assertIs(state.reset_done_today, True)
+
+            self.assertEqual(logs.output, ['WARNING:inverter.daily_reset:Assume daily reset is done for today'])
+
+            # It's stored to disk:
+            self.assertEqual(state.state_file_path.read_text(), '2020-01-01')
+
+            # Simulate a "fresh" start -> date should be read from disk:
+            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                state = DailyProductionResetState(config_path=temp_path)
+            self.assertEqual(state.last_reset.isoformat(), '2020-01-01')
+            self.assertIs(state.reset_done_today, True)
+            self.assertEqual(logs.output, ['INFO:inverter.daily_reset:Read last reset date: 2020-01-01'])
+
+            # Still the same day:
+            frozen_time.move_to('2020-01-01T23:59:59+0000')
+            self.assertIs(state.reset_done_today, True)
+
+            # Sleep a day ;)
+            frozen_time.move_to('2020-01-02T01:02:03+0000')
+            self.assertIs(state.reset_done_today, False)  # Next day -> reset not done
+            # File untouched:
+            self.assertEqual(state.last_reset.isoformat(), '2020-01-01')
+
+            # Simulate a "fresh" start -> date should be read from disk:
+            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                state = DailyProductionResetState(config_path=temp_path)
+            self.assertEqual(state.last_reset.isoformat(), '2020-01-01')
+            self.assertEqual(logs.output, ['INFO:inverter.daily_reset:Read last reset date: 2020-01-01'])
+            self.assertIs(state.reset_done_today, False)  # It's still the "next" day -> reset needed!
+
+            # Let's say the reset was done:
+            self.assertIs(state.reset_done_today, False)
+            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                state.reset_done()
+            self.assertIs(state.reset_done_today, True)
+            self.assertEqual(state.last_reset.isoformat(), '2020-01-02')
+            self.assertEqual(state.state_file_path.read_text(), '2020-01-02')
+            self.assertEqual(logs.output, ['INFO:inverter.daily_reset:Store today date 2020-01-02 to state file'])
+
+            # Simulate a "fresh" start:
+            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                state = DailyProductionResetState(config_path=temp_path)
+            self.assertEqual(state.last_reset.isoformat(), '2020-01-02')
+            self.assertEqual(logs.output, ['INFO:inverter.daily_reset:Read last reset date: 2020-01-02'])
+            self.assertIs(state.reset_done_today, True)
+
+            # Skip reset on same day:
+            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                state.reset_done()
+            self.assertEqual(logs.output, ['INFO:inverter.daily_reset:Reset already done today: Skip touch the disk'])
+
+            # What happen if file is corrupt:
+            state.state_file_path.write_text('Bam!')
+            with self.assertLogs(logger=None, level=logging.DEBUG) as logs:
+                DailyProductionResetState(config_path=temp_path)
             self.assertEqual(
                 logs.output,
                 [
-                    'INFO:inverter.daily_reset:Successfully reset counter. '
-                    'ResetState(started=FakeDatetime(2020, 1, 1, 0, 0), set_time_count=2, '
-                    'successful_count=1, last_success_dt=FakeDatetime(2020, 1, 1, 1, 6), '
-                    'reset_needed=False)',
-                    'DEBUG:inverter.daily_reset:Not needed: ResetState(started=FakeDatetime(2020, '
-                    '1, 1, 0, 0), set_time_count=2, successful_count=1, '
-                    'last_success_dt=FakeDatetime(2020, 1, 1, 1, 6), reset_needed=False)',
+                    'ERROR:inverter.daily_reset:Can not parse last reset date: Invalid isoformat ' "string: 'Bam!'",
+                    'WARNING:inverter.daily_reset:Assume daily reset is done for today',
+                    'INFO:inverter.daily_reset:Store today date 2020-01-02 to state file',
                 ],
             )
-            self.assertEqual(inverter.writes, [])  # no new set time writes


### PR DESCRIPTION
Save the information that the reset was done into a file and try the reset independ of the time. Just compare the current date.

So a reset will be made every day as long as it was successfully, then it's skipped until the next day.

Closes #60