### PR TITLE
Add configuration for inverter deye sun 8k/10k/12k sg04lp3

### DIFF
--- a/inverter/definitions/deye_sg04lp3.yaml
+++ b/inverter/definitions/deye_sg04lp3.yaml
@@ -1,0 +1,582 @@
+# Deye 12K EU tree Phase Hybrid
+# SUN-12K-SG04LP3 | 12KW | Three Phase | 2 MPPT | Hybrid Inverter | Low Voltage Battery
+# Modbus information retrieved from:Deye Modbus RTU tree Phase Energy Storage Communications Protokoll
+requests:
+  - start: 0x0003
+    end: 0x0059
+    mb_functioncode: 0x03
+  - start: 0x0204
+    end: 0x0210
+    mb_functioncode: 0x03
+  - start: 0x021C
+    end: 0x021D
+    mb_functioncode: 0x03
+  - start: 0x0229
+    end: 0x022E
+    mb_functioncode: 0x03
+  - start: 0x024A
+    end: 0x024D
+    mb_functioncode: 0x03
+  - start: 0x0256
+    end: 0x025E
+    mb_functioncode: 0x03
+  - start: 0x0260
+    end: 0x026A
+    mb_functioncode: 0x03
+  - start: 0x0276
+    end: 0x027C
+    mb_functioncode: 0x03
+  - start: 0x0284
+    end: 0x028D
+    mb_functioncode: 0x03
+  - start: 0x02A0
+    end: 0x02A7
+    mb_functioncode: 0x03
+  - start: 0x0085
+    end: 0x0086
+    mb_functioncode: 0x10
+
+parameters:
+ - group: solar
+   items:
+    - name: "PV1 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x02A0]
+      icon: 'mdi:solar-power'
+
+    - name: "PV2 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x02A1]
+      icon: 'mdi:solar-power'
+
+    - name: "PV1 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x02A4]
+      icon: 'mdi:solar-power'
+
+    - name: "PV2 Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x02A6]
+      icon: 'mdi:solar-power'
+
+    - name: "PV1 Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x02A5]
+      icon: 'mdi:solar-power'
+
+    - name: "PV2 Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.1
+      rule: 1
+      registers: [0x02A7]
+      icon: 'mdi:solar-power'
+
+    - name: "Daily Production"
+      class: "energy"
+      state_class: "measurement"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x01F5]
+      icon: 'mdi:solar-power'
+
+    - name: "Total Production"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x0216,0x0217]
+      icon: 'mdi:solar-power'
+
+ - group: Battery
+   items:
+    - name: "Battery Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x024E]
+      icon: 'mdi:battery'
+
+    - name: "Battery Voltage"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.01
+      rule: 1
+      registers: [0x024B]
+      icon: 'mdi:battery'
+
+    - name: "Battery Current"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 2
+      registers: [0x024F]
+      icon: 'mdi:battery'
+
+    - name: "Battery SOC"
+      class: "battery"
+      state_class: "measurement"
+      uom: "%"
+      scale: 1
+      rule: 1
+      registers: [0x024C]
+      icon: 'mdi:battery'
+
+    - name: "Daily Battery Charge"
+      class: "battery"
+      state_class: "measurement"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0202]
+      icon: 'mdi:battery'
+
+    - name: "Daily Battery Disharge"
+      class: "battery"
+      state_class: "measurement"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0203]
+      icon: 'mdi:battery'
+
+    - name: "Total Battery Charge"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x0204,0x0205]
+      icon: 'mdi:battery-plus'
+
+    - name: "Total Battery Discharge"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x0206,0x0207]
+      icon: 'mdi:battery-minus'
+
+    - name: "Battery Temperature"
+      class: "temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 0.1
+      rule: 1
+      offset: 1000
+      registers: [0x024A]
+      icon: 'mdi:battery'
+
+ - group: Grid
+   items:
+    - name: "Grid Frequency"
+      class: "frequency"
+      state_class: "measurement"
+      uom: "Hz"
+      scale: 0.01
+      rule: 1
+      registers: [0x0261]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Total Grid Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x0271]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Voltage L1"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0256]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Voltage L2"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0257]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Grid Voltage L3"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0258]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Internal CT L1 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x025C]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Internal CT L2 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x025D]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Internal CT L3 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x025E]
+      icon: 'mdi:transmission-tower'
+
+    - name: "External CT L1 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x0268]
+      icon: 'mdi:transmission-tower'
+
+    - name: "External CT L2 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x0269]
+      icon: 'mdi:transmission-tower'
+
+    - name: "External CT L3 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x026A]
+      icon: 'mdi:transmission-tower'
+
+    - name: "Daily Energy Bought"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0208]
+      icon: 'mdi:transmission-tower-export'
+
+    - name: "Total Energy Bought"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x020A,0x020B]
+      icon: 'mdi:transmission-tower-export'
+
+    - name: "Daily Energy Sold"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x0209]
+      icon: 'mdi:transmission-tower-import'
+
+    - name: "Total Energy Sold"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x020C,0x020D]
+      icon: 'mdi:transmission-tower-export'
+
+ - group: Upload
+   items:
+    - name: "Total Load Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x028D]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Load L1 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x028A]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Load L2 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x028B]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Load L3 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 1
+      registers: [0x028C]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Load Voltage L1"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0284]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Load Voltage L2"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0285]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Load Voltage L3"
+      class: "voltage"
+      state_class: "measurement"
+      uom: "V"
+      scale: 0.1
+      rule: 1
+      registers: [0x0286]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Daily Load Consumption"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 1
+      registers: [0x020E]
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Total Load Consumption"
+      class: "energy"
+      state_class: "total_increasing"
+      uom: "kWh"
+      scale: 0.1
+      rule: 3
+      registers: [0x020F,0x0210]
+      icon: 'mdi:lightning-bolt-outline'
+
+ - group: Inverter
+   items:
+
+    - name: "SmartLoad Enable Status"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x00C3]
+      isstr: true
+      lookup:
+      -  key: 0
+         value: "OFF"
+      -  key: 1
+         value: "ON"
+      icon: 'mdi:lightning-bolt-outline'
+
+    - name: "Running Status"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x01F4]
+      isstr: true
+      lookup:
+      -  key: 0
+         value: "Stand-by"
+      -  key: 1
+         value: "Self-checking"
+      -  key: 2
+         value: "Normal"
+      -  key: 3
+         value: "FAULT"
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Total Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x00AF]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Current L1"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 2
+      registers: [0x0276]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Current L2"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 2
+      registers: [0x0277]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Current L3"
+      class: "current"
+      state_class: "measurement"
+      uom: "A"
+      scale: 0.01
+      rule: 2
+      registers: [0x0278]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Inverter L1 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x0279]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Inverter L2 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x027A]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Inverter L3 Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 1
+      rule: 2
+      registers: [0x027B]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "DC Temperature"
+      class: "temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 0.1
+      rule: 2
+      offset: 1000
+      registers: [0x021C]
+      icon: 'mdi:thermometer'
+
+    - name: "AC Temperature"
+      class: "temperature"
+      state_class: "measurement"
+      uom: "°C"
+      scale: 0.1
+      rule: 2
+      offset: 1000
+      registers: [0x021D]
+      icon: 'mdi:thermometer'
+
+    - name: "Rated Power"
+      class: "power"
+      state_class: "measurement"
+      uom: "W"
+      scale: 0.1
+      rule: 3
+      registers: [0x0014,0x0015]
+      icon: 'mdi:home-lightning-bolt'
+
+    - name: "Inverter ID"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 5
+      registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
+      isstr: true
+
+    - name: "Communication Board Version No."
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x0011]
+      isstr: true
+
+    - name: "Control Board Version No."
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 1
+      registers: [0x000D]
+      isstr: true
+
+ - group: Alert
+   items:
+    - name: "Alert"
+      class: ""
+      state_class: ""
+      uom: ""
+      scale: 1
+      rule: 5
+      registers: [0x0229,0x022A,0x22B,0x022C,0x022D,0x022E]

--- a/inverter/definitions/deye_sg04lp3_validations.yaml
+++ b/inverter/definitions/deye_sg04lp3_validations.yaml
@@ -1,0 +1,8 @@
+validators:
+    - name: "AC Temperature"
+      type: "float"
+      min_value: -10
+      max_value: 60
+
+
+


### PR DESCRIPTION
Register configuration for deye sun 8k/10k/12k sg04lp3 was derived from https://github.com/StephanJoubert/home_assistant_solarman/blob/main/custom_components/solarman/inverter_definitions/deye_hybrid.yaml

Registers corrected
Duplicates removed
Registers added
Missing state_class added
Order uniqified to power,voltage,current,enery in all sections when possible