### PR TITLE
Fix version info when HEX value appears

### DIFF
--- a/inverter/api.py
+++ b/inverter/api.py
@@ -161,6 +161,6 @@ def fetch_inverter_versions(
         print(f'Fetch "{info.name}"', end='...')
         response: ModbusResponse = inv_sock.read(start_register=info.register, length=1)
         print(f'Result (in hex): [cyan]{response.data_hex}')
-        version = Version('.'.join(number for number in response.data_hex))
+        version = Version('.'.join(str(int(number, 16)) for number in response.data_hex))
         results.append(InverterRegisterVersionResult(info=info, data_hex=response.data_hex, version=version))
     return results

--- a/inverter/definitions/deye_2mppt.yaml
+++ b/inverter/definitions/deye_2mppt.yaml
@@ -199,8 +199,8 @@ parameters:
       icon: ''
 
     - name: "ON-OFF Enable"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -214,8 +214,8 @@ parameters:
       icon: 'mdi:toggle-switch'
 
     - name: "Island Protection Enable"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -246,8 +246,8 @@ parameters:
   - group: Inverter
     items:
     - name: "Running Status"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -357,8 +357,8 @@ parameters:
       isstr: true
 
     - name: "Soft Start Enable"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -381,8 +381,8 @@ parameters:
       icon: ''
 
     - name: "Restore Factory Settings"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1

--- a/inverter/definitions/deye_4mppt.yaml
+++ b/inverter/definitions/deye_4mppt.yaml
@@ -273,8 +273,8 @@ parameters:
       icon: ''
 
     - name: "ON-OFF Enable"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -288,8 +288,8 @@ parameters:
       icon: 'mdi:toggle-switch'
 
     - name: "Island Protection Enable"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -320,8 +320,8 @@ parameters:
   - group: Inverter
     items:
     - name: "Running Status"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -431,8 +431,8 @@ parameters:
       isstr: true
 
     - name: "Soft Start Enable"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1
@@ -455,8 +455,8 @@ parameters:
       icon: ''
 
     - name: "Restore Factory Settings"
-      class: ""
-      state_class: ""
+      class: "enum"
+      state_class: "measurement"
       uom: ""
       scale: 1
       rule: 1

--- a/inverter/definitions/deye_sg04lp3.yaml
+++ b/inverter/definitions/deye_sg04lp3.yaml
@@ -92,12 +92,15 @@ parameters:
 
       - name: "Daily Production"
         class: "energy"
-        state_class: "measurement"
+        state_class: "total_increasing"
         uom: "kWh"
         scale: 0.1
         rule: 1
-        registers: [0x01F5]
+        registers: [0x0211]
         icon: "mdi:solar-power"
+        validation:
+          max: 100
+          invalidate_all:
 
       - name: "Total Production"
         class: "energy"
@@ -105,11 +108,110 @@ parameters:
         uom: "kWh"
         scale: 0.1
         rule: 3
-        registers: [0x0216,0x0217]
+        registers: [0x0216, 0x0217]
         icon: "mdi:solar-power"
 
   - group: Battery
     items:
+      - name: "Battery Equalization V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0063]
+        icon: "mdi:battery"
+
+      - name: "Battery Absorption V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0064]
+        icon: "mdi:battery"
+
+      - name: "Battery Float V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0065]
+        icon: "mdi:battery"
+
+      - name: "Battery Capacity"
+        class: "battery"
+        state_class: "measurement"
+        uom: "Ah"
+        scale: 1
+        rule: 1
+        registers: [0x0066]
+        icon: "mdi:battery"
+
+      - name: "Battery Empty V"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x0066]
+        icon: "mdi:battery"
+
+      - name: "Battery Max A Charge"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 1
+        rule: 1
+        registers: [0x006C]
+        icon: "mdi:battery"
+
+      - name: "Battery Max A Discharge"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 1
+        rule: 1
+        registers: [0x006D]
+        icon: "mdi:battery"
+
+      - name: "Daily Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0202]
+        icon: "mdi:battery-plus"
+
+      - name: "Daily Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0203]
+        icon: "mdi:battery-plus"
+
+      - name: "Total Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0204, 0x0205]
+        icon: "mdi:battery-plus"
+
+      - name: "Total Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0206, 0x0207]
+        icon: "mdi:battery-minus"
+
       - name: "Battery Power"
         class: "power"
         state_class: "measurement"
@@ -128,15 +230,6 @@ parameters:
         registers: [0x024B]
         icon: "mdi:battery"
 
-      - name: "Battery Current"
-        class: "current"
-        state_class: "measurement"
-        uom: "A"
-        scale: 0.01
-        rule: 2
-        registers: [0x024F]
-        icon: "mdi:battery"
-
       - name: "Battery SOC"
         class: "battery"
         state_class: "measurement"
@@ -145,42 +238,18 @@ parameters:
         rule: 1
         registers: [0x024C]
         icon: "mdi:battery"
+        validation:
+          min: 0
+          max: 101
 
-      - name: "Daily Battery Charge"
-        class: "battery"
+      - name: "Battery Current"
+        class: "current"
         state_class: "measurement"
-        uom: "kWh"
-        scale: 0.1
-        rule: 1
-        registers: [0x0202]
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x024F]
         icon: "mdi:battery"
-
-      - name: "Daily Battery Disharge"
-        class: "battery"
-        state_class: "measurement"
-        uom: "kWh"
-        scale: 0.1
-        rule: 1
-        registers: [0x0203]
-        icon: "mdi:battery"
-
-      - name: "Total Battery Charge"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "kWh"
-        scale: 0.1
-        rule: 3
-        registers: [0x0204,0x0205]
-        icon: "mdi:battery-plus"
-
-      - name: "Total Battery Discharge"
-        class: "energy"
-        state_class: "total_increasing"
-        uom: "kWh"
-        scale: 0.1
-        rule: 3
-        registers: [0x0206,0x0207]
-        icon: "mdi:battery-minus"
 
       - name: "Battery Temperature"
         class: "temperature"
@@ -191,6 +260,9 @@ parameters:
         offset: 1000
         registers: [0x024A]
         icon: "mdi:battery"
+        validation:
+          min: 1
+          max: 99
 
   - group: Grid
     items:
@@ -204,7 +276,7 @@ parameters:
         icon: "mdi:transmission-tower"
 
       - name: "Total Grid Power"
-        class: "power"
+        class: "measurement"
         state_class: "measurement"
         uom: "W"
         scale: 1
@@ -308,7 +380,7 @@ parameters:
         uom: "kWh"
         scale: 0.1
         rule: 3
-        registers: [0x020A,0x020B]
+        registers: [0x020A, 0x020B]
         icon: "mdi:transmission-tower-export"
 
       - name: "Daily Energy Sold"
@@ -409,30 +481,14 @@ parameters:
         uom: "kWh"
         scale: 0.1
         rule: 3
-        registers: [0x020F,0x0210]
+        registers: [0x020F, 0x0210]
         icon: "mdi:lightning-bolt-outline"
 
   - group: Inverter
     items:
-
-      - name: "SmartLoad Enable Status"
-        class: ""
-        state_class: ""
-        uom: ""
-        scale: 1
-        rule: 1
-        registers: [0x00C3]
-        isstr: true
-        lookup:
-        -  key: 0
-           value: "OFF"
-        -  key: 1
-           value: "ON"
-        icon: "mdi:lightning-bolt-outline"
-
       - name: "Running Status"
-        class: ""
-        state_class: ""
+        state_class: "measurement"
+        class: "enum"
         uom: ""
         scale: 1
         rule: 1
@@ -547,7 +603,7 @@ parameters:
         uom: ""
         scale: 1
         rule: 5
-        registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
+        registers: [0x0003, 0x0004, 0x0005, 0x0006, 0x0007]
         isstr: true
 
       - name: "Communication Board Version No."
@@ -568,6 +624,120 @@ parameters:
         registers: [0x000D]
         isstr: true
 
+  - group: SmartLoad
+    items:
+      - name: "SmartLoad Enable Status"
+        class: "enum"
+        state_class: "measurement"
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x0085]
+        isstr: true
+        lookup:
+          - key: 0
+            value: "GEN Use"
+          - key: 1
+            value: "SMART Load output"
+          - key: 2
+            value: "Microinverter"
+        icon: "mdi:lightning-bolt-outline"
+        
+      - name: "Phase voltage of Gen port A"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0295]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase voltage of Gen port B"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0296]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase voltage of Gen port C"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0297]
+        icon: "mdi:home-lightning-bolt"
+
+      - name: "Phase power of Gen port A"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x0298]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Phase power of Gen port B"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x0299]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Phase power of Gen port C"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x029A]
+        icon: "mdi:home-lightning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Total Power of Gen port"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x029B]
+        icon: "mdi:home-l1ghtning-bolt"
+        validation:
+          min: 0
+          max: 12000
+
+      - name: "Generator daily power generation"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0218]
+        icon: "mdi:transmission-tower-import"
+
+      - name: "Generator total power generation"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0219, 0x021A]
+        icon: "mdi:transmission-tower-import"
+
+        
+        
   - group: Alert
     items:
       - name: "Alert"
@@ -576,4 +746,4 @@ parameters:
         uom: ""
         scale: 1
         rule: 5
-        registers: [0x0229,0x022A,0x22B,0x022C,0x022D,0x022E]
+        registers: [0x0229, 0x022A, 0x22B, 0x022C, 0x022D, 0x022E]

--- a/inverter/definitions/deye_sg04lp3.yaml
+++ b/inverter/definitions/deye_sg04lp3.yaml
@@ -5,578 +5,575 @@ requests:
   - start: 0x0003
     end: 0x0059
     mb_functioncode: 0x03
-  - start: 0x0204
-    end: 0x0210
+  - start: 0x0063
+    end: 0x006D
     mb_functioncode: 0x03
-  - start: 0x021C
-    end: 0x021D
+  - start: 0x0085
+    end: 0x0085
     mb_functioncode: 0x03
-  - start: 0x0229
+  - start: 0x0202
     end: 0x022E
     mb_functioncode: 0x03
+  - start: 0x0218
+    end: 0x021A
+    mb_functioncode: 0x03
   - start: 0x024A
-    end: 0x024D
+    end: 0x024F
     mb_functioncode: 0x03
   - start: 0x0256
-    end: 0x025E
-    mb_functioncode: 0x03
-  - start: 0x0260
-    end: 0x026A
-    mb_functioncode: 0x03
-  - start: 0x0276
     end: 0x027C
     mb_functioncode: 0x03
   - start: 0x0284
     end: 0x028D
     mb_functioncode: 0x03
+  - start: 0x0295
+    end: 0x029F
+    mb_functioncode: 0x03
   - start: 0x02A0
     end: 0x02A7
     mb_functioncode: 0x03
-  - start: 0x0085
-    end: 0x0086
-    mb_functioncode: 0x10
 
 parameters:
- - group: solar
-   items:
-    - name: "PV1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x02A0]
-      icon: 'mdi:solar-power'
+  - group: solar
+    items:
+      - name: "PV1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x02A0]
+        icon: "mdi:solar-power"
 
-    - name: "PV2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x02A1]
-      icon: 'mdi:solar-power'
+      - name: "PV2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x02A1]
+        icon: "mdi:solar-power"
 
-    - name: "PV1 Voltage"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A4]
-      icon: 'mdi:solar-power'
+      - name: "PV1 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A4]
+        icon: "mdi:solar-power"
 
-    - name: "PV2 Voltage"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A6]
-      icon: 'mdi:solar-power'
+      - name: "PV2 Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A6]
+        icon: "mdi:solar-power"
 
-    - name: "PV1 Current"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A5]
-      icon: 'mdi:solar-power'
+      - name: "PV1 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A5]
+        icon: "mdi:solar-power"
 
-    - name: "PV2 Current"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.1
-      rule: 1
-      registers: [0x02A7]
-      icon: 'mdi:solar-power'
+      - name: "PV2 Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.1
+        rule: 1
+        registers: [0x02A7]
+        icon: "mdi:solar-power"
 
-    - name: "Daily Production"
-      class: "energy"
-      state_class: "measurement"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x01F5]
-      icon: 'mdi:solar-power'
+      - name: "Daily Production"
+        class: "energy"
+        state_class: "measurement"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x01F5]
+        icon: "mdi:solar-power"
 
-    - name: "Total Production"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x0216,0x0217]
-      icon: 'mdi:solar-power'
+      - name: "Total Production"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0216,0x0217]
+        icon: "mdi:solar-power"
 
- - group: Battery
-   items:
-    - name: "Battery Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x024E]
-      icon: 'mdi:battery'
+  - group: Battery
+    items:
+      - name: "Battery Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x024E]
+        icon: "mdi:battery"
 
-    - name: "Battery Voltage"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.01
-      rule: 1
-      registers: [0x024B]
-      icon: 'mdi:battery'
+      - name: "Battery Voltage"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.01
+        rule: 1
+        registers: [0x024B]
+        icon: "mdi:battery"
 
-    - name: "Battery Current"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x024F]
-      icon: 'mdi:battery'
+      - name: "Battery Current"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x024F]
+        icon: "mdi:battery"
 
-    - name: "Battery SOC"
-      class: "battery"
-      state_class: "measurement"
-      uom: "%"
-      scale: 1
-      rule: 1
-      registers: [0x024C]
-      icon: 'mdi:battery'
+      - name: "Battery SOC"
+        class: "battery"
+        state_class: "measurement"
+        uom: "%"
+        scale: 1
+        rule: 1
+        registers: [0x024C]
+        icon: "mdi:battery"
 
-    - name: "Daily Battery Charge"
-      class: "battery"
-      state_class: "measurement"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0202]
-      icon: 'mdi:battery'
+      - name: "Daily Battery Charge"
+        class: "battery"
+        state_class: "measurement"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0202]
+        icon: "mdi:battery"
 
-    - name: "Daily Battery Disharge"
-      class: "battery"
-      state_class: "measurement"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0203]
-      icon: 'mdi:battery'
+      - name: "Daily Battery Disharge"
+        class: "battery"
+        state_class: "measurement"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0203]
+        icon: "mdi:battery"
 
-    - name: "Total Battery Charge"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x0204,0x0205]
-      icon: 'mdi:battery-plus'
+      - name: "Total Battery Charge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0204,0x0205]
+        icon: "mdi:battery-plus"
 
-    - name: "Total Battery Discharge"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x0206,0x0207]
-      icon: 'mdi:battery-minus'
+      - name: "Total Battery Discharge"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x0206,0x0207]
+        icon: "mdi:battery-minus"
 
-    - name: "Battery Temperature"
-      class: "temperature"
-      state_class: "measurement"
-      uom: "°C"
-      scale: 0.1
-      rule: 1
-      offset: 1000
-      registers: [0x024A]
-      icon: 'mdi:battery'
+      - name: "Battery Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 1
+        offset: 1000
+        registers: [0x024A]
+        icon: "mdi:battery"
 
- - group: Grid
-   items:
-    - name: "Grid Frequency"
-      class: "frequency"
-      state_class: "measurement"
-      uom: "Hz"
-      scale: 0.01
-      rule: 1
-      registers: [0x0261]
-      icon: 'mdi:transmission-tower'
+  - group: Grid
+    items:
+      - name: "Grid Frequency"
+        class: "frequency"
+        state_class: "measurement"
+        uom: "Hz"
+        scale: 0.01
+        rule: 1
+        registers: [0x0261]
+        icon: "mdi:transmission-tower"
 
-    - name: "Total Grid Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0271]
-      icon: 'mdi:transmission-tower'
+      - name: "Total Grid Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0271]
+        icon: "mdi:transmission-tower"
 
-    - name: "Grid Voltage L1"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0256]
-      icon: 'mdi:transmission-tower'
+      - name: "Grid Voltage L1"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0256]
+        icon: "mdi:transmission-tower"
 
-    - name: "Grid Voltage L2"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0257]
-      icon: 'mdi:transmission-tower'
+      - name: "Grid Voltage L2"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0257]
+        icon: "mdi:transmission-tower"
 
-    - name: "Grid Voltage L3"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0258]
-      icon: 'mdi:transmission-tower'
+      - name: "Grid Voltage L3"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0258]
+        icon: "mdi:transmission-tower"
 
-    - name: "Internal CT L1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x025C]
-      icon: 'mdi:transmission-tower'
+      - name: "Internal CT L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025C]
+        icon: "mdi:transmission-tower"
 
-    - name: "Internal CT L2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x025D]
-      icon: 'mdi:transmission-tower'
+      - name: "Internal CT L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025D]
+        icon: "mdi:transmission-tower"
 
-    - name: "Internal CT L3 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x025E]
-      icon: 'mdi:transmission-tower'
+      - name: "Internal CT L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x025E]
+        icon: "mdi:transmission-tower"
 
-    - name: "External CT L1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0268]
-      icon: 'mdi:transmission-tower'
+      - name: "External CT L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0268]
+        icon: "mdi:transmission-tower"
 
-    - name: "External CT L2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0269]
-      icon: 'mdi:transmission-tower'
+      - name: "External CT L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0269]
+        icon: "mdi:transmission-tower"
 
-    - name: "External CT L3 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x026A]
-      icon: 'mdi:transmission-tower'
+      - name: "External CT L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x026A]
+        icon: "mdi:transmission-tower"
 
-    - name: "Daily Energy Bought"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0208]
-      icon: 'mdi:transmission-tower-export'
+      - name: "Daily Energy Bought"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0208]
+        icon: "mdi:transmission-tower-export"
 
-    - name: "Total Energy Bought"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x020A,0x020B]
-      icon: 'mdi:transmission-tower-export'
+      - name: "Total Energy Bought"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x020A,0x020B]
+        icon: "mdi:transmission-tower-export"
 
-    - name: "Daily Energy Sold"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x0209]
-      icon: 'mdi:transmission-tower-import'
+      - name: "Daily Energy Sold"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x0209]
+        icon: "mdi:transmission-tower-import"
 
-    - name: "Total Energy Sold"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x020C,0x020D]
-      icon: 'mdi:transmission-tower-export'
+      - name: "Total Energy Sold"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x020C,0x020D]
+        icon: "mdi:transmission-tower-export"
 
- - group: Upload
-   items:
-    - name: "Total Load Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028D]
-      icon: 'mdi:lightning-bolt-outline'
+  - group: Upload
+    items:
+      - name: "Total Load Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028D]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Load L1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028A]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Load L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028A]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Load L2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028B]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Load L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028B]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Load L3 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 1
-      registers: [0x028C]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Load L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 1
+        registers: [0x028C]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Load Voltage L1"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0284]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Load Voltage L1"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0284]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Load Voltage L2"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0285]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Load Voltage L2"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0285]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Load Voltage L3"
-      class: "voltage"
-      state_class: "measurement"
-      uom: "V"
-      scale: 0.1
-      rule: 1
-      registers: [0x0286]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Load Voltage L3"
+        class: "voltage"
+        state_class: "measurement"
+        uom: "V"
+        scale: 0.1
+        rule: 1
+        registers: [0x0286]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Daily Load Consumption"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 1
-      registers: [0x020E]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Daily Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 1
+        registers: [0x020E]
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Total Load Consumption"
-      class: "energy"
-      state_class: "total_increasing"
-      uom: "kWh"
-      scale: 0.1
-      rule: 3
-      registers: [0x020F,0x0210]
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "Total Load Consumption"
+        class: "energy"
+        state_class: "total_increasing"
+        uom: "kWh"
+        scale: 0.1
+        rule: 3
+        registers: [0x020F,0x0210]
+        icon: "mdi:lightning-bolt-outline"
 
- - group: Inverter
-   items:
+  - group: Inverter
+    items:
 
-    - name: "SmartLoad Enable Status"
-      class: ""
-      state_class: ""
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x00C3]
-      isstr: true
-      lookup:
-      -  key: 0
-         value: "OFF"
-      -  key: 1
-         value: "ON"
-      icon: 'mdi:lightning-bolt-outline'
+      - name: "SmartLoad Enable Status"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x00C3]
+        isstr: true
+        lookup:
+        -  key: 0
+           value: "OFF"
+        -  key: 1
+           value: "ON"
+        icon: "mdi:lightning-bolt-outline"
 
-    - name: "Running Status"
-      class: ""
-      state_class: ""
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x01F4]
-      isstr: true
-      lookup:
-      -  key: 0
-         value: "Stand-by"
-      -  key: 1
-         value: "Self-checking"
-      -  key: 2
-         value: "Normal"
-      -  key: 3
-         value: "FAULT"
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Running Status"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x01F4]
+        isstr: true
+        lookup:
+        -  key: 0
+           value: "Stand-by"
+        -  key: 1
+           value: "Self-checking"
+        -  key: 2
+           value: "Normal"
+        -  key: 3
+           value: "FAULT"
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Total Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x00AF]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Total Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x00AF]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Current L1"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x0276]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Current L1"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0276]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Current L2"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x0277]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Current L2"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0277]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Current L3"
-      class: "current"
-      state_class: "measurement"
-      uom: "A"
-      scale: 0.01
-      rule: 2
-      registers: [0x0278]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Current L3"
+        class: "current"
+        state_class: "measurement"
+        uom: "A"
+        scale: 0.01
+        rule: 2
+        registers: [0x0278]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Inverter L1 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x0279]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Inverter L1 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x0279]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Inverter L2 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x027A]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Inverter L2 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x027A]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Inverter L3 Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 1
-      rule: 2
-      registers: [0x027B]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Inverter L3 Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 1
+        rule: 2
+        registers: [0x027B]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "DC Temperature"
-      class: "temperature"
-      state_class: "measurement"
-      uom: "°C"
-      scale: 0.1
-      rule: 2
-      offset: 1000
-      registers: [0x021C]
-      icon: 'mdi:thermometer'
+      - name: "DC Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        offset: 1000
+        registers: [0x021C]
+        icon: "mdi:thermometer"
 
-    - name: "AC Temperature"
-      class: "temperature"
-      state_class: "measurement"
-      uom: "°C"
-      scale: 0.1
-      rule: 2
-      offset: 1000
-      registers: [0x021D]
-      icon: 'mdi:thermometer'
+      - name: "AC Temperature"
+        class: "temperature"
+        state_class: "measurement"
+        uom: "°C"
+        scale: 0.1
+        rule: 2
+        offset: 1000
+        registers: [0x021D]
+        icon: "mdi:thermometer"
 
-    - name: "Rated Power"
-      class: "power"
-      state_class: "measurement"
-      uom: "W"
-      scale: 0.1
-      rule: 3
-      registers: [0x0014,0x0015]
-      icon: 'mdi:home-lightning-bolt'
+      - name: "Rated Power"
+        class: "power"
+        state_class: "measurement"
+        uom: "W"
+        scale: 0.1
+        rule: 3
+        registers: [0x0014,0x0015]
+        icon: "mdi:home-lightning-bolt"
 
-    - name: "Inverter ID"
-      class: ""
-      state_class: ""
-      uom: ""
-      scale: 1
-      rule: 5
-      registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
-      isstr: true
+      - name: "Inverter ID"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        registers: [0x0003,0x0004,0x0005,0x0006,0x0007]
+        isstr: true
 
-    - name: "Communication Board Version No."
-      class: ""
-      state_class: ""
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x0011]
-      isstr: true
+      - name: "Communication Board Version No."
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x0011]
+        isstr: true
 
-    - name: "Control Board Version No."
-      class: ""
-      state_class: ""
-      uom: ""
-      scale: 1
-      rule: 1
-      registers: [0x000D]
-      isstr: true
+      - name: "Control Board Version No."
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 1
+        registers: [0x000D]
+        isstr: true
 
- - group: Alert
-   items:
-    - name: "Alert"
-      class: ""
-      state_class: ""
-      uom: ""
-      scale: 1
-      rule: 5
-      registers: [0x0229,0x022A,0x22B,0x022C,0x022D,0x022E]
+  - group: Alert
+    items:
+      - name: "Alert"
+        class: ""
+        state_class: ""
+        uom: ""
+        scale: 1
+        rule: 5
+        registers: [0x0229,0x022A,0x22B,0x022C,0x022D,0x022E]

--- a/inverter/utilities/cli.py
+++ b/inverter/utilities/cli.py
@@ -71,7 +71,7 @@ def print_register(inv_sock, start_register, length):
         )
 
 
-def print_inverter_versions(results: list[InverterRegisterVersionResult], title='Inventer Version Information'):
+def print_inverter_versions(results: list[InverterRegisterVersionResult], title='Inverter Version Information'):
     table = Table(title=title)
     table.add_column('Counter\n', justify='right')
     table.add_column('Name\n', justify='right')


### PR DESCRIPTION
It appears that the communication protocol version number major grew over 9 and caused python to crash.
This is now fixed with conversion to decimal and to string to be joined. 

```
                           Inventer Version Information                           
┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┓
┃ Counter ┃                         Name ┃ Address ┃ Address ┃ Value ┃           ┃
┃         ┃                              ┃  (hex)  ┃   (dec) ┃ (hex) ┃   Version ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━┩
│       1 │       Control Board Firmware │   0xd   │      13 │ 0000  │  v0.0.0.0 │
│       2 │ Communication Board Firmware │   0xf   │      15 │ 2006  │  v2.0.0.6 │
│       3 │       Communication Protocol │  0x14   │      20 │ c043  │ v12.0.4.3 │
└─────────┴──────────────────────────────┴─────────┴─────────┴───────┴───────────┘
```